### PR TITLE
feat/refactor: revalidate-tag api endpoint, adjust revalidating time, refactor queries and fetcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ HYGRAPH_AUTH_TOKEN=
 PRODUCTS_PER_PAGE=
 # string to protect an api route responsible for deleting expired carts from database generated eg. by node -e "console.log(crypto.randomBytes(32).toString('hex'))"
 CRON_SECRET=
+# secret key to sign the payload of your webhook (string)
+HYGRAPH_WEBHOOK_SECRET=
 # number of days how long cookie should persist in browser
 COOKIE_MAX_AGE_IN_DAYS=
 # stripe config

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "e2e:ui": "pnpm exec playwright test --ui"
   },
   "dependencies": {
+    "@hygraph/utils": "^1.2.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@hygraph/utils':
+    specifier: ^1.2.1
+    version: 1.2.1
   '@radix-ui/react-dialog':
     specifier: ^1.0.5
     version: 1.0.5(@types/react-dom@18.2.10)(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)
@@ -2621,6 +2624,10 @@ packages:
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+
+  /@hygraph/utils@1.2.1:
+    resolution: {integrity: sha512-Eu4xKWAAzAhWUcgxSzgL+6o5alCItry1Jo0LtsnQ3q3/EaGHeI3Z/kMuGvsFf8zrhyAljeSHC4otwRc5ibMinQ==}
+    dev: false
 
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}

--- a/src/lib/env.mjs
+++ b/src/lib/env.mjs
@@ -7,6 +7,7 @@ export const env = createEnv({
     HYGRAPH_AUTH_TOKEN: z.string(),
     PRODUCTS_PER_PAGE: z.coerce.number().int().min(1).optional().default(8),
     CRON_SECRET: z.string(),
+    HYGRAPH_WEBHOOK_SECRET: z.string(),
     COOKIE_MAX_AGE_IN_DAYS: z.coerce.number().int().min(1),
     VERCEL_ENV: z.string().optional(),
     STRIPE_SECRET_KEY: z.string(),
@@ -22,6 +23,7 @@ export const env = createEnv({
     HYGRAPH_AUTH_TOKEN: process.env.HYGRAPH_AUTH_TOKEN,
     PRODUCTS_PER_PAGE: process.env.PRODUCTS_PER_PAGE,
     CRON_SECRET: process.env.CRON_SECRET,
+    HYGRAPH_WEBHOOK_SECRET: process.env.HYGRAPH_WEBHOOK_SECRET,
     COOKIE_MAX_AGE_IN_DAYS: process.env.COOKIE_MAX_AGE_IN_DAYS,
     VERCEL_ENV: process.env.VERCEL_ENV,
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY:

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -24,18 +24,15 @@ export async function fetcher<Result, Variables>({
   headers,
   cache,
   method = "POST",
-  tags,
+  next,
 }: {
   method?: HTTPRequestMethods;
   query: TypedDocumentString<Result, Variables>;
   variables: Variables;
   headers?: HeadersInit;
   cache?: RequestCache;
-  tags?: NextFetchRequestConfig["tags"];
+  next?: NextFetchRequestConfig;
 }): Promise<Result> {
-  const options = cache
-    ? { cache, next: { tags } }
-    : { next: { revalidate: 900, tags } };
   const result = await fetch(endpoint, {
     method,
     headers: {
@@ -47,7 +44,8 @@ export async function fetcher<Result, Variables>({
       query: query.toString(),
       ...(variables && { variables }),
     }),
-    ...options,
+    cache,
+    next,
   });
 
   const body = (await result.json()) as GraphQlErrorRespone<Result>;

--- a/src/lib/queries/cart/getCartById.ts
+++ b/src/lib/queries/cart/getCartById.ts
@@ -14,7 +14,7 @@ export const getCartById = async ({ id }: Args) => {
       cartId: id,
     },
     cache: "no-store",
-    tags: [TAGS.cart],
+    next: { tags: [TAGS.cart] },
   });
 
   return result.cart ? reshapeCart(result.cart) : null;

--- a/src/lib/queries/categories/getCategories.ts
+++ b/src/lib/queries/categories/getCategories.ts
@@ -7,7 +7,7 @@ export const getCategories = async () => {
   const result = await fetcher({
     query: GetCategoriesDocument,
     variables: {},
-    tags: [TAGS.categories],
+    next: { tags: [TAGS.categories] },
   });
 
   return result.categories.map((category) => reshapeCategory(category));

--- a/src/lib/queries/categories/getCategoriesBySlugs.ts
+++ b/src/lib/queries/categories/getCategoriesBySlugs.ts
@@ -13,7 +13,7 @@ export const getCategoriesBySlugs = async ({ slugs }: Args) => {
     variables: {
       slugs,
     },
-    tags: [TAGS.categories],
+    next: { tags: [TAGS.categories] },
   });
 
   return result.categories.map((category) => reshapeCategory(category));

--- a/src/lib/queries/categories/getCategoryNameBySlug.ts
+++ b/src/lib/queries/categories/getCategoryNameBySlug.ts
@@ -11,7 +11,7 @@ export const getCategoryNameBySlug = async ({ slug }: Args) => {
   const result = await fetcher({
     query: GetCategoryNameBySlugDocument,
     variables: { categorySlug: slug },
-    tags: [TAGS.categories],
+    next: { tags: [TAGS.categories] },
   });
 
   return result.category ? reshapeCategory(result.category) : null;

--- a/src/lib/queries/pages/getPageBySlug.ts
+++ b/src/lib/queries/pages/getPageBySlug.ts
@@ -12,8 +12,7 @@ export const getPageBySlug = async ({ slug }: Args) => {
     variables: {
       slug,
     },
-    cache: "force-cache",
-    tags: [TAGS.pages],
+    next: { tags: [TAGS.pages] },
   });
 
   return result.page ? result.page : null;

--- a/src/lib/queries/products/getAllProducts.ts
+++ b/src/lib/queries/products/getAllProducts.ts
@@ -25,7 +25,7 @@ export const getAllProducts = async ({
       order,
       searchQuery: searchQuery || "",
     },
-    tags: [TAGS.products],
+    next: { tags: [TAGS.products], revalidate: 60 },
   });
 
   return {

--- a/src/lib/queries/products/getProductBySlug.ts
+++ b/src/lib/queries/products/getProductBySlug.ts
@@ -11,7 +11,7 @@ export const getProductBySlug = async ({ slug }: Args) => {
   const result = await fetcher({
     query: GetProductBySlugDocument,
     variables: { slug },
-    tags: [TAGS.products],
+    next: { tags: [TAGS.products], revalidate: 300 },
   });
 
   return result.product ? reshapeProductWithDetails(result.product) : null;

--- a/src/lib/queries/products/getProductsByCategorySlug.ts
+++ b/src/lib/queries/products/getProductsByCategorySlug.ts
@@ -25,7 +25,7 @@ export const getProductsByCategorySlug = async ({
       categorySlug,
       order,
     },
-    tags: [TAGS.categories, TAGS.products],
+    next: { tags: [TAGS.categories, TAGS.products], revalidate: 60 },
   });
 
   return {


### PR DESCRIPTION
- Integrate revalidate-tag api endpoint with hygraph to take use from signature received in request from hygraph.
- Refactor fetcher - replace options with `next` object from next.js - it gives more contorol on revalidate time, cache options and reevalidating tags.
- Adjust queries to refactored fetcher.